### PR TITLE
Remove redundant reset in search results function

### DIFF
--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -172,8 +172,7 @@ const context = [
 ];
 
 export async function getSearchResults(searchQuery: string) {
-  let searchResults: SearchResult[] = [];
-  searchResults = [];
+  const searchResults: SearchResult[] = [];
   console.log("Searching for:", searchQuery);
   const response = await fetch(
     `https://www.googleapis.com/customsearch/v1?q=${searchQuery + ' "review"'}&cx=${process.env.PSE_CX}&key=${process.env.PSE_API_KEY}`,


### PR DESCRIPTION
## Summary
- clean up `getSearchResults` by removing the extra `searchResults = []` line
- use `const` for the `searchResults` array initialization

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b69056ca08333986e05892d3ece7e